### PR TITLE
receive_messageでmessage_attributeに対応

### DIFF
--- a/faws/sqs/message.py
+++ b/faws/sqs/message.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+import dataclasses
+import datetime
+import enum
+import uuid
+from typing import Dict, Optional
+
+
+def generate_uuid() -> str:
+    return str(uuid.uuid4())
+
+
+class MessageAttributeType(enum.Enum):
+    BINARY = "Binary"
+    STRING = "String"
+    NUMBER = "Number"
+
+
+@dataclasses.dataclass
+class MessageAttribute:
+    data_type: MessageAttributeType
+    value: str
+
+    @classmethod
+    def from_request_data(cls, request_message_attribute_data: Dict) -> Optional[Dict[str, MessageAttribute]]:
+        if not request_message_attribute_data or len(request_message_attribute_data) == 0:
+            return None
+
+        num_attributes = int(len(request_message_attribute_data) / 3)
+        message_attributes = {}
+        for i in range(1, num_attributes + 1):
+            attribute_name = request_message_attribute_data[f"MessageAttribute.{i}.Name"]
+            try:
+                attribute_data_type = MessageAttributeType(
+                    request_message_attribute_data[f"MessageAttribute.{i}.Value.DataType"]
+                )
+                if attribute_data_type == MessageAttributeType.STRING:
+                    attribute_value = request_message_attribute_data[
+                        f"MessageAttribute.{i}.Value.StringValue"
+                    ]
+                if attribute_data_type == MessageAttributeType.NUMBER:
+                    attribute_value = request_message_attribute_data[
+                        f"MessageAttribute.{i}.Value.StringValue"
+                    ]
+                if attribute_data_type == MessageAttributeType.BINARY:
+                    attribute_value = request_message_attribute_data[
+                        f"MessageAttribute.{i}.Value.BinaryValue"
+                    ]
+            except ValueError:
+                raise ValueError(f"The type of message(user) attribute '{attribute_name}' is invalid. "
+                                 f"You must use only the following supported type prefixes: Binary, Number, String")
+            message_attributes[attribute_name] = MessageAttribute(
+                attribute_data_type, attribute_value
+            )
+
+        return message_attributes
+
+    def to_dict(self) -> Dict[str, Dict]:
+        return {
+            "Value": {
+                # String/Numberの場合はStringValue, Binaryの場合はBinaryValueとする
+                "StringValue" if self.data_type != MessageAttributeType.BINARY else "BinaryValue": self.value,
+                "DataType": self.data_type.value
+            }
+        }
+
+
+@dataclasses.dataclass
+class Message:
+    message_body: str
+    message_attributes: Optional[Dict[str, MessageAttribute]] = None
+    delay_seconds: int = 0
+    message_system_attributes: Optional[Dict] = None
+    message_deduplication_id: Optional[str] = None
+    message_group_id: Optional[str] = None
+    message_inserted_at: datetime = datetime.datetime.now()
+    message_id: str = dataclasses.field(init=False)
+    message_deliverable_time: datetime = dataclasses.field(init=False)
+
+    def __post_init__(self):
+        self.message_attributes = MessageAttribute.from_request_data(self.message_attributes)
+        self.message_id = generate_uuid()
+        self.message_deliverable_time = self.message_inserted_at + datetime.timedelta(seconds=self.delay_seconds)
+
+    def is_callable(self):
+        return True

--- a/faws/sqs/message.py
+++ b/faws/sqs/message.py
@@ -57,11 +57,9 @@ class MessageAttribute:
 
     def to_dict(self) -> Dict[str, Dict]:
         return {
-            "Value": {
-                # String/Numberの場合はStringValue, Binaryの場合はBinaryValueとする
-                "StringValue" if self.data_type != MessageAttributeType.BINARY else "BinaryValue": self.value,
-                "DataType": self.data_type.value
-            }
+            # String/Numberの場合はStringValue, Binaryの場合はBinaryValueとする
+            "StringValue" if self.data_type != MessageAttributeType.BINARY else "BinaryValue": self.value,
+            "DataType": self.data_type.value
         }
 
 

--- a/faws/sqs/queue.py
+++ b/faws/sqs/queue.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import datetime
 from faws.sqs.message import Message
-from typing import Dict
+from typing import Dict, Optional
 
 
 class Queue:
@@ -47,10 +47,11 @@ class Queue:
         self._messages[message.message_id] = message
         return message
 
-    def get_message(self) -> Message:
+    def get_message(self) -> Optional[Message]:
         for message_id, message in self.messages.items():
             if message.is_callable():
                 return message
+        return None
 
     def __eq__(self, other: Queue) -> bool:
         return self.queue_url == other.queue_url \

--- a/faws/sqs/queue.py
+++ b/faws/sqs/queue.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 import datetime
-import uuid
-import dataclasses
-from typing import Dict, Optional
+from faws.sqs.message import Message
+from typing import Dict
 
 
 class Queue:
@@ -57,32 +56,3 @@ class Queue:
         return self.queue_url == other.queue_url \
                and self.queue_name == other.queue_name \
                and self.created_at == other.created_at
-
-
-def generate_uuid() -> str:
-    return str(uuid.uuid4())
-
-
-@dataclasses.dataclass
-class Message:
-    message_body: str
-    message_attributes: Optional[Dict] = None
-    delay_seconds: int = 0
-    message_system_attributes: Optional[Dict] = None
-    message_deduplication_id: Optional[str] = None
-    message_group_id: Optional[str] = None
-    message_inserted_at: datetime = datetime.datetime.now()
-    message_id: str = dataclasses.field(init=False)
-    message_deliverable_time: datetime = dataclasses.field(init=False)
-
-    def __post_init__(self):
-        self.message_id = generate_uuid()
-        self.message_deliverable_time = self.message_inserted_at + datetime.timedelta(seconds=self.delay_seconds)
-
-    def get_message_attribute(self, message_attribute_name: str) -> Optional[Dict]:
-        if message_attribute_name == "All":
-            return self.message_attributes
-        return self.message_attributes.get(message_attribute_name)
-
-    def is_callable(self):
-        return True

--- a/faws/sqs/queue.py
+++ b/faws/sqs/queue.py
@@ -79,5 +79,10 @@ class Message:
         self.message_id = generate_uuid()
         self.message_deliverable_time = self.message_inserted_at + datetime.timedelta(seconds=self.delay_seconds)
 
+    def get_message_attribute(self, message_attribute_name: str) -> Optional[Dict]:
+        if message_attribute_name == "All":
+            return self.message_attributes
+        return self.message_attributes.get(message_attribute_name)
+
     def is_callable(self):
         return True

--- a/faws/sqs/server.py
+++ b/faws/sqs/server.py
@@ -91,20 +91,23 @@ def receive_message(QueueUrl: str, **kwargs):
     queue_name = queue_name_from_queue_url(QueueUrl)
     message_attribute_names = {k: v for k, v in kwargs.items() if "MessageAttribute" in k}
     queue = queues.get_queue(queue_name)
-    message = queue.get_message()
     response_data = {
         "ReceiveMessageResponse": {
-            "ReceiveMessageResult": {
-                "Message": {
-                    "MessageId": message.message_id,
-                    "ReceiptHandle": "barbar",
-                    "MD5OFBody": "hogehoge",
-                    "Body": message.message_body,
-                }
-            },
             "ResponseMetadata": {
                 "RequestId": "725275ae-0b9b-4762-b238-436d7c65a1ac"
             }
+        }
+    }
+    message = queue.get_message()
+    if message is None:
+        return response_data
+
+    response_data["ReceiveMessageResponse"]["ReceiveMessageResult"] = {
+        "Message": {
+            "MessageId": message.message_id,
+            "ReceiptHandle": "barbar",
+            "MD5OFBody": "hogehoge",
+            "Body": message.message_body,
         }
     }
     if len(message_attribute_names) == 0:

--- a/faws/sqs/server.py
+++ b/faws/sqs/server.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional, List
 from faws.sqs.message import MessageAttribute, MessageAttributeType
 from faws.sqs.queues import Queues
 from faws.sqs.queues_storage import QueuesStorageType
-import dicttoxml
+from dict2xml import dict2xml
 import re
 import urllib
 
@@ -163,7 +163,7 @@ def index():
     )
 
     result = do_operation(request_data)
-    response_data = dicttoxml.dicttoxml(result, root=False, item_func=lambda x: "QueueUrl")
+    response_data = dict2xml(result)
     return Response(
         response_data,
         mimetype="text/xml"

--- a/poetry.lock
+++ b/poetry.lock
@@ -40,11 +40,14 @@ version = "0.4.3"
 
 [[package]]
 category = "main"
-description = "Converts a Python dictionary or other native data type into a valid XML string."
-name = "dicttoxml"
+description = "Small utility to convert a python dictionary into an XML string"
+name = "dict2xml"
 optional = false
 python-versions = "*"
-version = "1.7.4"
+version = "1.7.0"
+
+[package.extras]
+tests = ["noseOfYeti (2.0.1)", "pytest (5.3.1)"]
 
 [[package]]
 category = "main"
@@ -231,7 +234,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "06355828b02d6a8ee0ef97c7eb53fa578564b8f59c78d9a22299e1c1971ed9de"
+content-hash = "c2b3956a12b6c532be6af9b475558879a680e3e3058ec35f5f3978a81a786ca6"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -251,8 +254,8 @@ colorama = [
     {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
     {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
 ]
-dicttoxml = [
-    {file = "dicttoxml-1.7.4.tar.gz", hash = "sha256:ea44cc4ec6c0f85098c57a431a1ee891b3549347b07b7414c8a24611ecf37e45"},
+dict2xml = [
+    {file = "dict2xml-1.7.0.tar.gz", hash = "sha256:1446e7d89b39630e53c20eb38e05046216e3dd72a822954fe7548fa59145d62d"},
 ]
 flask = [
     {file = "Flask-1.1.2-py2.py3-none-any.whl", hash = "sha256:8a4fdd8936eba2512e9c85df320a37e694c93945b33ef33c89946a340a238557"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["takeru911 <t.maehara911@gmail.com>"]
 [tool.poetry.dependencies]
 python = "^3.7"
 flask = "^1.1.2"
-dicttoxml = "^1.7.4"
+dict2xml = "^1.7.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.4.3"

--- a/tests/sqs/test_message.py
+++ b/tests/sqs/test_message.py
@@ -20,15 +20,15 @@ def test_from_request_data():
 @pytest.mark.parametrize("message_attribute,expected", [
     (
             MessageAttribute(MessageAttributeType.BINARY, "hogehuga"),
-            {"Value": {"BinaryValue": "hogehuga", "DataType": "Binary"}}
+            {"BinaryValue": "hogehuga", "DataType": "Binary"}
     ),
     (
             MessageAttribute(MessageAttributeType.NUMBER, "123"),
-            {"Value": {"StringValue": "123", "DataType": "Number"}}
+            {"StringValue": "123", "DataType": "Number"}
     ),
     (
             MessageAttribute(MessageAttributeType.STRING, "tenteketen"),
-            {"Value": {"StringValue": "tenteketen", "DataType": "String"}}
+            {"StringValue": "tenteketen", "DataType": "String"}
     ),
 
 ])

--- a/tests/sqs/test_message.py
+++ b/tests/sqs/test_message.py
@@ -1,0 +1,37 @@
+import pytest
+from faws.sqs.message import MessageAttribute, MessageAttributeType
+
+def test_from_request_data():
+    request_data = {
+        'MessageAttribute.1.Name': 'City', 'MessageAttribute.1.Value.DataType': 'String','MessageAttribute.1.Value.StringValue': 'Any+City',
+        'MessageAttribute.2.Name': 'Greeting', 'MessageAttribute.2.Value.DataType': 'Binary', 'MessageAttribute.2.Value.BinaryValue': 'SGVsbG8sIFdvcmxkIQ%3D%3D',
+        'MessageAttribute.3.Name': 'Population', 'MessageAttribute.3.Value.DataType': 'Number', 'MessageAttribute.3.Value.StringValue': '1250800',
+    }
+
+    actual = MessageAttribute.from_request_data(request_data)
+    expected = {
+        "City": MessageAttribute(MessageAttributeType.STRING, "Any+City"),
+        "Greeting": MessageAttribute(MessageAttributeType.BINARY, "SGVsbG8sIFdvcmxkIQ%3D%3D"),
+        "Population": MessageAttribute(MessageAttributeType.NUMBER, "1250800"),
+    }
+    assert actual == expected
+
+
+@pytest.mark.parametrize("message_attribute,expected", [
+    (
+            MessageAttribute(MessageAttributeType.BINARY, "hogehuga"),
+            {"Value": {"BinaryValue": "hogehuga", "DataType": "Binary"}}
+    ),
+    (
+            MessageAttribute(MessageAttributeType.NUMBER, "123"),
+            {"Value": {"StringValue": "123", "DataType": "Number"}}
+    ),
+    (
+            MessageAttribute(MessageAttributeType.STRING, "tenteketen"),
+            {"Value": {"StringValue": "tenteketen", "DataType": "String"}}
+    ),
+
+])
+def test_message_attribute_to_dict(message_attribute, expected):
+    actual = message_attribute.to_dict()
+    assert actual == expected

--- a/tests/sqs/test_queue.py
+++ b/tests/sqs/test_queue.py
@@ -41,3 +41,12 @@ def test_get_message():
         )
 
         assert queue.get_message() == message
+
+def test_get_message_exist_uncallable_message():
+    queue = Queue("test-queue")
+
+    with mock.patch("faws.sqs.message.Message.is_callable", return_value=False):
+        message = queue.add_message(
+            "takerun"
+        )
+        assert queue.get_message() is None

--- a/tests/sqs/test_server.py
+++ b/tests/sqs/test_server.py
@@ -67,7 +67,7 @@ def test_do_get_queue_url(created_queue_server):
 
 
 def test_do_send_message(created_queue_server):
-    with mock.patch("faws.sqs.queue.generate_uuid", return_value="1111"):
+    with mock.patch("faws.sqs.message.generate_uuid", return_value="1111"):
         assert created_queue_server.do_operation(
             {
                 "Action": "SendMessage",
@@ -111,18 +111,3 @@ def test_queue_name_from_queue_url_invalid_url():
         server.queue_name_from_queue_url(invalid_url)
 
 
-def test_parse_message_attribute():
-    raw_message_attribute = {
-        'MessageAttribute.1.Name': 'City', 'MessageAttribute.1.Value.DataType': 'String','MessageAttribute.1.Value.StringValue': 'Any+City',
-        'MessageAttribute.2.Name': 'Greeting', 'MessageAttribute.2.Value.DataType': 'Binary', 'MessageAttribute.2.Value.BinaryValue': 'SGVsbG8sIFdvcmxkIQ%3D%3D',
-        'MessageAttribute.3.Name': 'Population', 'MessageAttribute.3.Value.DataType': 'Number', 'MessageAttribute.3.Value.StringValue': '1250800',
-    }
-    print(raw_message_attribute.items())
-
-    actual = server.parse_message_attribute(raw_message_attribute)
-    expected = {
-        "City": {"StringValue": "Any+City", "DataType": "String"},
-        "Greeting": {"BinaryValue": "SGVsbG8sIFdvcmxkIQ%3D%3D", "DataType": "Binary"},
-        "Population": {"StringValue": "1250800", "DataType": "Number"},
-    }
-    assert actual == expected

--- a/tests/sqs/test_server.py
+++ b/tests/sqs/test_server.py
@@ -6,7 +6,6 @@ from faws.sqs import server
 @pytest.fixture
 def created_queue_server():
     server.create_queue("test_queue_1")
-
     return server
 
 
@@ -75,11 +74,146 @@ def test_do_send_message(created_queue_server):
                 "MessageBody": "taker"
             }
         ) == {
-            "SendMessageResponse": {
-                "SendMessageResult": {
-                    "MD5OfMessageBody": "hogehoge",
-                    "MD5OfMessageAttributes": "hugahuga",
-                    "MessageId": "1111"
+                   "SendMessageResponse": {
+                       "SendMessageResult": {
+                           "MD5OfMessageBody": "hogehoge",
+                           "MD5OfMessageAttributes": "hugahuga",
+                           "MessageId": "1111"
+                       },
+                       "ResponseMetadata": {
+                           "RequestId": "725275ae-0b9b-4762-b238-436d7c65a1ac"
+                       }
+                   }
+               }
+
+
+def test_do_receive_message():
+    server.create_queue("test_receive_queue")
+    assert server.do_operation(
+            {
+                "Action": "ReceiveMessage",
+                "QueueUrl": "http://localhost:5000/queues/test_receive_queue",
+            }
+        ) == {
+        "ReceiveMessageResponse": {
+            "ResponseMetadata": {
+                "RequestId": "725275ae-0b9b-4762-b238-436d7c65a1ac"
+            }
+        }
+    }
+
+
+def test_receive_message_non_attribute():
+    queue_name = "test_receive_queue"
+    server.create_queue(queue_name)
+    with mock.patch("faws.sqs.message.generate_uuid", return_value="1111"):
+        server.queues.get_queue(queue_name).add_message(
+            "hogehoge",
+            {"MessageAttribute"}
+        )
+        queue_url = f"http://localhost/queues/{queue_name}"
+        response = server.receive_message(queue_url)
+        assert response == {
+            "ReceiveMessageResponse": {
+                "ReceiveMessageResult": {
+                    "Message": {
+                        "MessageId": "1111",
+                        "ReceiptHandle": "barbar",
+                        "MD5OFBody": "hogehoge",
+                        "Body": "hogehoge",
+                    }
+                },
+                "ResponseMetadata": {
+                    "RequestId": "725275ae-0b9b-4762-b238-436d7c65a1ac"
+                }
+            }
+        }
+
+
+def test_receive_message_with_attribute_select_one():
+    queue_name = "test_receive_queue_attr"
+    server.create_queue(queue_name)
+    with mock.patch("faws.sqs.message.generate_uuid", return_value="1111"):
+        server.queues.get_queue(queue_name).add_message(
+            "hogehoge", message_attributes={
+                "MessageAttribute.1.Name": "v1",
+                "MessageAttribute.1.Value.DataType": "String",
+                "MessageAttribute.1.Value.StringValue": "hoge",
+                "MessageAttribute.2.Name": "v2",
+                "MessageAttribute.2.Value.DataType": "Number",
+                "MessageAttribute.2.Value.StringValue": "123",
+            }
+        )
+        queue_url = f"http://localhost/queues/{queue_name}"
+        response = server.receive_message(queue_url, **{
+            "MessageAttribute.1.Name": "v1",
+            "MessageAttribute.2.Name": "v2"
+        })
+        assert response == {
+            "ReceiveMessageResponse": {
+                "ReceiveMessageResult": {
+                    "Message": {
+                        "MessageId": "1111",
+                        "ReceiptHandle": "barbar",
+                        "MD5OFBody": "hogehoge",
+                        "Body": "hogehoge",
+                        "MessageAttribute": [
+                            {"Name": "v1", "Value": {
+                                "DataType": "String",
+                                "StringValue": "hoge"
+                            }},
+                            {"Name": "v2", "Value": {
+                                "DataType": "Number",
+                                "StringValue": "123"
+                            }}
+                        ]
+                    }
+                },
+                "ResponseMetadata": {
+                    "RequestId": "725275ae-0b9b-4762-b238-436d7c65a1ac"
+                }
+            }
+        }
+
+
+
+def test_receive_message_with_attribute_select_all():
+    queue_name = "test_receive_queue_attr"
+    server.create_queue(queue_name)
+    with mock.patch("faws.sqs.message.generate_uuid", return_value="1111"):
+        server.queues.get_queue(queue_name).add_message(
+            "hogehoge", message_attributes={
+                "MessageAttribute.1.Name": "v1",
+                "MessageAttribute.1.Value.DataType": "String",
+                "MessageAttribute.1.Value.StringValue": "hoge",
+                "MessageAttribute.2.Name": "v2",
+                "MessageAttribute.2.Value.DataType": "Number",
+                "MessageAttribute.2.Value.StringValue": "123",
+            }
+        )
+        queue_url = f"http://localhost/queues/{queue_name}"
+        response = server.receive_message(queue_url, **{
+            "MessageAttribute.1.Name": "All"
+        })
+        assert response == {
+            "ReceiveMessageResponse": {
+                "ReceiveMessageResult": {
+                    "Message": {
+                        "MessageId": "1111",
+                        "ReceiptHandle": "barbar",
+                        "MD5OFBody": "hogehoge",
+                        "Body": "hogehoge",
+                        "MessageAttribute": [
+                            {"Name": "v1", "Value": {
+                                "DataType": "String",
+                                "StringValue": "hoge"
+                            }},
+                            {"Name": "v2", "Value": {
+                                "DataType": "Number",
+                                "StringValue": "123"
+                            }}
+                        ]
+                    }
                 },
                 "ResponseMetadata": {
                     "RequestId": "725275ae-0b9b-4762-b238-436d7c65a1ac"
@@ -109,5 +243,3 @@ def test_queue_name_from_queue_url_invalid_url():
     invalid_url = "hoge://hugahuga/queue"
     with pytest.raises(ValueError):
         server.queue_name_from_queue_url(invalid_url)
-
-


### PR DESCRIPTION
## 概要

- receive_messageでmessage_attributeを指定することでmessage_attributeを取得できるように
- messageのファイルを独立させた
  - MessageAttribute, MessageAttributeTypeを作り処理を簡略に
  - message_attributesの組み立てをMessageAttributeでやるように
  - これにともないsend周りも色々修正