### PR TITLE
serverのglobal変数にqueuesを持たせるのをやめる

### DIFF
--- a/faws/sqs/queues.py
+++ b/faws/sqs/queues.py
@@ -14,6 +14,9 @@ class Queues:
     def queues(self):
         return self._queues_storage.queues
 
+    def init_queues(self):
+        self._queues_storage.init_storage()
+
     def create_queue(self, queue_name: str) -> Queue:
         queue = self._queues_storage.get_queue(queue_name)
         if queue is not None:

--- a/faws/sqs/queues_storage.py
+++ b/faws/sqs/queues_storage.py
@@ -14,6 +14,11 @@ class QueuesStorage:
     def __init__(self, **kwargs):
         pass
 
+    @classmethod
+    @abstractmethod
+    def init_storage(cls):
+        raise NotImplementedError
+
     @abstractmethod
     def queues(self):
         raise NotImplementedError
@@ -32,14 +37,18 @@ class QueuesStorage:
 
 
 class InMemoryQueuesStorage(QueuesStorage):
+    _queues = {}
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._queues = {}
+
+    @classmethod
+    def init_storage(cls):
+        cls._queues = {}
 
     @property
     def queues(self):
-        return self._queues
+        return InMemoryQueuesStorage._queues
 
     def create_queue(self, queue_name: str) -> Queue:
         if queue_name in self.queues:
@@ -47,7 +56,7 @@ class InMemoryQueuesStorage(QueuesStorage):
         queue = Queue(
             queue_name=queue_name
         )
-        self._queues[queue_name] = queue
+        InMemoryQueuesStorage._queues[queue_name] = queue
 
         return queue
 


### PR DESCRIPTION
# 概要

- serverのglobal変数にqueuesをもたせていたが、テストだったり今後の初期化とかでデメリットが多すぎるので直した
  - どのように永続化?するかは各Storageに任せるように
    - MemoryStorageだったらクラス変数で行うように
  - flaskのgにqueuesへの参照をもたせている
     - 今後dbとかに対応させるとき用に
  - それに伴ってserverのメソッドを直接指定してテストしていたのをちゃんとtest用のflask appを立てて行うようにした