### PR TITLE
request_idを自動生成するように

### DIFF
--- a/faws/sqs/server.py
+++ b/faws/sqs/server.py
@@ -3,8 +3,10 @@ from typing import Dict, List
 from faws.sqs.message import MessageAttribute
 from faws.sqs.queues import Queues, QueuesStorageType
 from dict2xml import dict2xml
+import dataclasses
 import re
 import urllib
+import uuid
 
 
 def init_queues():
@@ -31,38 +33,29 @@ def parse_request_data(request_data: str):
     return parsed_data
 
 
-def create_queue(QueueName: str, **kwargs):
+@dataclasses.dataclass()
+class Result:
+    operation_name: str
+    result_data: Dict
+
+
+def create_queue(QueueName: str, **kwargs) -> Dict:
     queue = get_queues().create_queue(QueueName)
-    return {
-        "CreateQueueResponse": {
-            "CreateQueueResult": {"QueueUrl": queue.queue_url},
-            "ResponseMetadata": {"RequestId": "725275ae-0b9b-4762-b238-436d7c65a1ac"},
-        }
-    }
+    return {"QueueUrl": queue.queue_url}
 
 
-def get_list_queues(**kwargs):
+def get_list_queues(**kwargs) -> Dict:
     queue_urls = [queue.queue_url for queue in get_queues().get_queues()]
 
-    return {
-        "ListQueuesResponse": {
-            "ListQueuesResult": {"QueueUrl": queue_urls},
-            "ResponseMetadata": {"RequestId": "725275ae-0b9b-4762-b238-436d7c65a1ac"},
-        }
-    }
+    return {"QueueUrl": queue_urls}
 
 
-def get_queue_url(QueueName: str, **kwargs):
+def get_queue_url(QueueName: str, **kwargs) -> Dict:
     queue = get_queues().get_queue(QueueName)
-    return {
-        "GetQueueUrlResponse": {
-            "GetQueueUrlResult": {"QueueUrl": queue.queue_url},
-            "ResponseMetadata": {"RequestId": "725275ae-0b9b-4762-b238-436d7c65a1ac"},
-        }
-    }
+    return {"QueueUrl": queue.queue_url}
 
 
-def send_message(QueueUrl: str, MessageBody: str, **kwargs):
+def send_message(QueueUrl: str, MessageBody: str, **kwargs) -> Dict:
     queue_name = queue_name_from_queue_url(QueueUrl)
     queue = get_queues().get_queue(queue_name)
     # message_attributeは
@@ -76,33 +69,23 @@ def send_message(QueueUrl: str, MessageBody: str, **kwargs):
     )
 
     return {
-        "SendMessageResponse": {
-            "SendMessageResult": {
-                "MD5OfMessageBody": "hogehoge",
-                "MD5OfMessageAttributes": "hugahuga",
-                "MessageId": message.message_id,
-            },
-            "ResponseMetadata": {"RequestId": "725275ae-0b9b-4762-b238-436d7c65a1ac"},
-        }
+        "MD5OfMessageBody": "hogehoge",
+        "MD5OfMessageAttributes": "hugahuga",
+        "MessageId": message.message_id,
     }
 
 
-def receive_message(QueueUrl: str, **kwargs):
+def receive_message(QueueUrl: str, **kwargs) -> Dict:
     queue_name = queue_name_from_queue_url(QueueUrl)
     message_attribute_names = {
         k: v for k, v in kwargs.items() if "MessageAttribute" in k
     }
     queue = get_queues().get_queue(queue_name)
-    response_data = {
-        "ReceiveMessageResponse": {
-            "ResponseMetadata": {"RequestId": "725275ae-0b9b-4762-b238-436d7c65a1ac"}
-        }
-    }
+
     message = queue.get_message()
     if message is None:
-        return response_data
-
-    response_data["ReceiveMessageResponse"]["ReceiveMessageResult"] = {
+        return {}
+    result_data = {
         "Message": {
             "MessageId": message.message_id,
             "ReceiptHandle": "barbar",
@@ -111,14 +94,14 @@ def receive_message(QueueUrl: str, **kwargs):
         }
     }
     if len(message_attribute_names) == 0:
-        return response_data
+        return result_data
     message_attributes = select_message_attribute(
         message.message_attributes, list(message_attribute_names.values())
     )
-    response_data["ReceiveMessageResponse"]["ReceiveMessageResult"]["Message"][
-        "MessageAttribute"
-    ] = [{"Name": k, "Value": v.to_dict()} for k, v in message_attributes.items()]
-    return response_data
+    result_data["Message"]["MessageAttribute"] = [
+        {"Name": k, "Value": v.to_dict()} for k, v in message_attributes.items()
+    ]
+    return result_data
 
 
 def select_message_attribute(
@@ -143,19 +126,35 @@ def queue_name_from_queue_url(queue_url: str) -> str:
     return m.groups()[0]
 
 
-def do_operation(request_data: Dict):
+def do_operation(request_data: Dict) -> Result:
     action = request_data["Action"]
     if action == "ListQueues":
-        return get_list_queues(**request_data)
+        return Result(action, get_list_queues(**request_data))
     if action == "GetQueueUrl":
-        return get_queue_url(**request_data)
+        return Result(action, get_queue_url(**request_data))
     if action == "CreateQueue":
-        return create_queue(**request_data)
+        return Result(action, create_queue(**request_data))
     if action == "SendMessage":
-        return send_message(**request_data)
+        return Result(action, send_message(**request_data))
     if action == "ReceiveMessage":
-        return receive_message(**request_data)
+        return Result(action, receive_message(**request_data))
     raise NotImplementedError()
+
+
+def run_request_to_index(request):
+    request_id = uuid.uuid4()
+    request_data = parse_request_data(request.get_data().decode(encoding="utf-8"))
+
+    result = do_operation(request_data)
+    response_data = dict2xml(
+        {
+            f"{result.operation_name}Response": {
+                f"{result.operation_name}Result": result.result_data,
+                "ResponseMetadata": {"RequestId": request_id},
+            }
+        }
+    )
+    return response_data
 
 
 def create_app(app_config: Dict = None):
@@ -166,10 +165,7 @@ def create_app(app_config: Dict = None):
 
     @app.route("/", methods=["POST"])
     def index():
-        request_data = parse_request_data(request.get_data().decode(encoding="utf-8"))
-
-        result = do_operation(request_data)
-        response_data = dict2xml(result)
+        response_data = run_request_to_index(request)
         return Response(response_data, mimetype="text/xml")
 
     return app

--- a/tests/sqs/test_server.py
+++ b/tests/sqs/test_server.py
@@ -58,7 +58,8 @@ def test_parse_request_data():
     assert actual == expected
 
 
-def test_do_list_queues(client):
+@mock.patch("uuid.uuid4", return_value="725275ae-0b9b-4762-b238-436d7c65a1ac")
+def test_do_list_queues(uuid, client):
     create_queue(client, "test_queue_1")
     create_queue(client, "test_queue_2")
     assert list_queues(client).data == dict2xml_bytes(
@@ -78,7 +79,8 @@ def test_do_list_queues(client):
     )
 
 
-def test_do_create_queue(client):
+@mock.patch("uuid.uuid4", return_value="725275ae-0b9b-4762-b238-436d7c65a1ac")
+def test_do_create_queue(uuid, client):
     response = create_queue(client, "test-queue")
 
     assert response.data == dict2xml_bytes(
@@ -95,7 +97,8 @@ def test_do_create_queue(client):
     )
 
 
-def test_do_get_queue_url(client):
+@mock.patch("uuid.uuid4", return_value="725275ae-0b9b-4762-b238-436d7c65a1ac")
+def test_do_get_queue_url(uuid, client):
     create_queue(client, "test_queue_1")
 
     assert get_queue_url(client, "test_queue_1").data == dict2xml_bytes(
@@ -112,7 +115,8 @@ def test_do_get_queue_url(client):
     )
 
 
-def test_do_send_message(client):
+@mock.patch("uuid.uuid4", return_value="725275ae-0b9b-4762-b238-436d7c65a1ac")
+def test_do_send_message(uuid, client):
     create_queue(client, "test_queue_1")
     with mock.patch("faws.sqs.message.generate_uuid", return_value="1111"):
         assert send_message(
@@ -133,7 +137,8 @@ def test_do_send_message(client):
         )
 
 
-def test_send_message_with_attribute(client):
+@mock.patch("uuid.uuid4", return_value="725275ae-0b9b-4762-b238-436d7c65a1ac")
+def test_send_message_with_attribute(uuid, client):
     create_queue(client, "test_queue_1")
     with mock.patch("faws.sqs.message.generate_uuid", return_value="1111"):
         assert send_message(
@@ -161,22 +166,25 @@ def test_send_message_with_attribute(client):
         )
 
 
-def test_do_receive_message_non_message(client):
+@mock.patch("uuid.uuid4", return_value="725275ae-0b9b-4762-b238-436d7c65a1ac")
+def test_do_receive_message_non_message(uuid, client):
     create_queue(client, "test_receive_queue")
     assert receive_message(
         client, "http://localhost:5000/queues/test_receive_queue"
     ).data == dict2xml_bytes(
         {
             "ReceiveMessageResponse": {
+                "ReceiveMessageResult": {},
                 "ResponseMetadata": {
                     "RequestId": "725275ae-0b9b-4762-b238-436d7c65a1ac"
-                }
+                },
             }
         }
     )
 
 
-def test_receive_message_non_attribute(client):
+@mock.patch("uuid.uuid4", return_value="725275ae-0b9b-4762-b238-436d7c65a1ac")
+def test_receive_message_non_attribute(uuid, client):
     queue_name = "test_receive_queue"
     create_queue(client, queue_name)
     queue_url = f"http://localhost/queues/{queue_name}"
@@ -201,6 +209,7 @@ def test_receive_message_non_attribute(client):
         )
 
 
+@mock.patch("uuid.uuid4", return_value="725275ae-0b9b-4762-b238-436d7c65a1ac")
 @pytest.mark.parametrize(
     "attribute_names_pattern",
     [
@@ -208,7 +217,7 @@ def test_receive_message_non_attribute(client):
         {"MessageAttribute.1.Name": "All",},
     ],
 )
-def test_receive_message_with_attribute(client, attribute_names_pattern):
+def test_receive_message_with_attribute(uuid, client, attribute_names_pattern):
     queue_name = "test_receive_queue_attr"
     queue_url = f"http://localhost/queues/{queue_name}"
     create_queue(client, queue_name)


### PR DESCRIPTION
# 概要　

- 定数で決めていたrequest_idをuuid4で生成するように
- それに伴って各actionで最後まで生成していたresponse_dataをリファクタ
  - 各アクションはそのアクションの結果データだけを返す
    - その際にResult classにアクション名と結果データを入れる
  - 返されたResultを見て正しいresponse_dataを作成する