### PR TITLE
messageのvisibility timeoutに対応

### DIFF
--- a/faws/sqs/message.py
+++ b/faws/sqs/message.py
@@ -77,12 +77,13 @@ class MessageAttribute:
 
 
 class Message:
-    def __init__(self,
-                 message_body: str,
-                 message_attributes: Optional[Dict] = None,
-                 delay_seconds: int = 0,
-                 visibility_timeout: int = 30
-                 ):
+    def __init__(
+        self,
+        message_body: str,
+        message_attributes: Optional[Dict] = None,
+        delay_seconds: int = 0,
+        visibility_timeout: int = 30,
+    ):
         self._message_body = message_body
         self._message_attributes = MessageAttribute.from_request_data(
             message_attributes

--- a/faws/sqs/message.py
+++ b/faws/sqs/message.py
@@ -111,6 +111,11 @@ class Message:
     def message_deliverable_time(self) -> datetime:
         return self._message_deliverable_time
 
+    def update_deliverable_time(self, visibility_timeout: int):
+        self._message_deliverable_time = datetime.datetime.now() + datetime.timedelta(
+            seconds=visibility_timeout
+        )
+
     def is_callable(self) -> bool:
         if self._message_deliverable_time <= datetime.datetime.now():
             return True

--- a/faws/sqs/message.py
+++ b/faws/sqs/message.py
@@ -76,26 +76,42 @@ class MessageAttribute:
         }
 
 
-@dataclasses.dataclass
 class Message:
-    message_body: str
-    message_attributes: Optional[Dict[str, MessageAttribute]] = None
-    delay_seconds: int = 0
-    message_system_attributes: Optional[Dict] = None
-    message_deduplication_id: Optional[str] = None
-    message_group_id: Optional[str] = None
-    message_inserted_at: datetime = datetime.datetime.now()
-    message_id: str = dataclasses.field(init=False)
-    message_deliverable_time: datetime = dataclasses.field(init=False)
-
-    def __post_init__(self):
-        self.message_attributes = MessageAttribute.from_request_data(
-            self.message_attributes
+    def __init__(self,
+                 message_body: str,
+                 message_attributes: Optional[Dict] = None,
+                 delay_seconds: int = 0,
+                 visibility_timeout: int = 30
+                 ):
+        self._message_body = message_body
+        self._message_attributes = MessageAttribute.from_request_data(
+            message_attributes
         )
-        self.message_id = generate_uuid()
-        self.message_deliverable_time = self.message_inserted_at + datetime.timedelta(
-            seconds=self.delay_seconds
+        self._delay_seconds = delay_seconds
+        self._message_id = generate_uuid()
+        self._message_inserted_at = datetime.datetime.now()
+        self._message_deliverable_time = self._message_inserted_at + datetime.timedelta(
+            seconds=self._delay_seconds
         )
+        self._visibility_timeout = visibility_timeout
 
-    def is_callable(self):
-        return True
+    @property
+    def message_body(self) -> str:
+        return self._message_body
+
+    @property
+    def message_attributes(self) -> Dict[str, MessageAttribute]:
+        return self._message_attributes
+
+    @property
+    def message_id(self) -> str:
+        return self._message_id
+
+    @property
+    def message_deliverable_time(self) -> datetime:
+        return self._message_deliverable_time
+
+    def is_callable(self) -> bool:
+        if self._message_deliverable_time <= datetime.datetime.now():
+            return True
+        return False

--- a/faws/sqs/queue.py
+++ b/faws/sqs/queue.py
@@ -46,9 +46,13 @@ class Queue:
         self._messages[message.message_id] = message
         return message
 
-    def get_message(self) -> Optional[Message]:
+    def get_message(self, visibility_timeout: int = None) -> Optional[Message]:
         for message_id, message in self.messages.items():
             if message.is_callable():
+                if visibility_timeout is None:
+                    message.update_deliverable_time(self.default_visibility_timeout)
+                    return message
+                message.update_deliverable_time(visibility_timeout)
                 return message
         return None
 

--- a/faws/sqs/queue.py
+++ b/faws/sqs/queue.py
@@ -5,11 +5,12 @@ from typing import Dict, Optional
 
 
 class Queue:
-    def __init__(self, queue_name: str):
+    def __init__(self, queue_name: str, default_visibility_timeout: int = 30):
         self._queue_name = queue_name
         self._queue_url = f"https://localhost:5000/queues/{self.queue_name}"
         self._created_at = datetime.datetime.now()
         self._messages = {}
+        self._default_visibility_timeout = default_visibility_timeout
 
     @property
     def queue_name(self) -> str:
@@ -27,22 +28,20 @@ class Queue:
     def messages(self):
         return self._messages
 
+    @property
+    def default_visibility_timeout(self) -> int:
+        return self._default_visibility_timeout
+
     def add_message(
         self,
         message_body: str,
         message_attributes: Dict = None,
         delay_seconds: int = 0,
-        message_system_attributes: Dict = None,
-        message_deduplication_id: str = None,
-        message_group_id: str = None,
     ) -> Message:
         message = Message(
             message_body,
             message_attributes=message_attributes,
             delay_seconds=delay_seconds,
-            message_system_attributes=message_system_attributes,
-            message_deduplication_id=message_deduplication_id,
-            message_group_id=message_group_id,
         )
         self._messages[message.message_id] = message
         return message

--- a/faws/sqs/server.py
+++ b/faws/sqs/server.py
@@ -55,7 +55,7 @@ def get_queue_url(QueueName: str, **kwargs) -> Dict:
     return {"QueueUrl": queue.queue_url}
 
 
-def send_message(QueueUrl: str, MessageBody: str, **kwargs) -> Dict:
+def send_message(QueueUrl: str, MessageBody: str,  DelaySeconds: str = 0, **kwargs) -> Dict:
     queue_name = queue_name_from_queue_url(QueueUrl)
     queue = get_queues().get_queue(queue_name)
     # message_attributeは
@@ -65,7 +65,7 @@ def send_message(QueueUrl: str, MessageBody: str, **kwargs) -> Dict:
     message = queue.add_message(
         MessageBody,
         message_attributes=message_attributes,
-        delay_seconds=int(kwargs.get("DelaySeconds", "0")),
+        delay_seconds=int(DelaySeconds),
     )
 
     return {

--- a/faws/sqs/server.py
+++ b/faws/sqs/server.py
@@ -55,7 +55,9 @@ def get_queue_url(QueueName: str, **kwargs) -> Dict:
     return {"QueueUrl": queue.queue_url}
 
 
-def send_message(QueueUrl: str, MessageBody: str,  DelaySeconds: str = 0, **kwargs) -> Dict:
+def send_message(
+    QueueUrl: str, MessageBody: str, DelaySeconds: str = 0, **kwargs
+) -> Dict:
     queue_name = queue_name_from_queue_url(QueueUrl)
     queue = get_queues().get_queue(queue_name)
     # message_attributeは
@@ -75,14 +77,16 @@ def send_message(QueueUrl: str, MessageBody: str,  DelaySeconds: str = 0, **kwar
     }
 
 
-def receive_message(QueueUrl: str, VisibilityTimeout: str = None,**kwargs) -> Dict:
+def receive_message(QueueUrl: str, VisibilityTimeout: str = None, **kwargs) -> Dict:
     queue_name = queue_name_from_queue_url(QueueUrl)
     message_attribute_names = {
         k: v for k, v in kwargs.items() if "MessageAttribute" in k
     }
     queue = get_queues().get_queue(queue_name)
 
-    message = queue.get_message(int(VisibilityTimeout) if VisibilityTimeout is not None else None)
+    message = queue.get_message(
+        int(VisibilityTimeout) if VisibilityTimeout is not None else None
+    )
     if message is None:
         return {}
     result_data = {

--- a/faws/sqs/server.py
+++ b/faws/sqs/server.py
@@ -94,6 +94,7 @@ def receive_message(QueueUrl: str, **kwargs) -> Dict:
         }
     }
     if len(message_attribute_names) == 0:
+        message.update_deliverable_time(queue.default_visibility_timeout)
         return result_data
     message_attributes = select_message_attribute(
         message.message_attributes, list(message_attribute_names.values())
@@ -101,6 +102,8 @@ def receive_message(QueueUrl: str, **kwargs) -> Dict:
     result_data["Message"]["MessageAttribute"] = [
         {"Name": k, "Value": v.to_dict()} for k, v in message_attributes.items()
     ]
+    # メッセージの配信可能時間を現時刻 + Queueのデフォルト可視性タイムアウトで更新する
+    message.update_deliverable_time(queue.default_visibility_timeout)
     return result_data
 
 

--- a/tests/sqs/test_message.py
+++ b/tests/sqs/test_message.py
@@ -55,18 +55,13 @@ def test_message_set_delay():
     deliverable_time = datetime.datetime(2020, 5, 28, 0, 0, 10)
     with unittest.mock.patch("datetime.datetime") as dt:
         dt.now.return_value = now
-        message = Message(
-            message_body="hoge",
-            delay_seconds=10,
-        )
+        message = Message(message_body="hoge", delay_seconds=10,)
 
     assert message.message_deliverable_time == deliverable_time
 
 
 def test_is_callable():
-    message = Message(
-        "test"
-    )
+    message = Message("test")
 
     assert message.is_callable()
     now = datetime.datetime(2020, 5, 10, 0, 0, 0)
@@ -74,12 +69,8 @@ def test_is_callable():
     # delay_secondを増やした状態で正しくcallableの値を返すか
     with unittest.mock.patch("datetime.datetime") as dt:
         dt.now.return_value = now
-        message = Message(
-            "test", delay_seconds=30
-        )
+        message = Message("test", delay_seconds=30)
         assert not message.is_callable()
 
         dt.now.return_value = now_after_delay
         assert message.is_callable()
-
-

--- a/tests/sqs/test_message.py
+++ b/tests/sqs/test_message.py
@@ -1,5 +1,7 @@
+import datetime
 import pytest
-from faws.sqs.message import MessageAttribute, MessageAttributeType
+import unittest.mock
+from faws.sqs.message import Message, MessageAttribute, MessageAttributeType
 
 
 def test_from_request_data():
@@ -46,3 +48,38 @@ def test_from_request_data():
 def test_message_attribute_to_dict(message_attribute, expected):
     actual = message_attribute.to_dict()
     assert actual == expected
+
+
+def test_message_set_delay():
+    now = datetime.datetime(2020, 5, 28, 0, 0, 0)
+    deliverable_time = datetime.datetime(2020, 5, 28, 0, 0, 10)
+    with unittest.mock.patch("datetime.datetime") as dt:
+        dt.now.return_value = now
+        message = Message(
+            message_body="hoge",
+            delay_seconds=10,
+        )
+
+    assert message.message_deliverable_time == deliverable_time
+
+
+def test_is_callable():
+    message = Message(
+        "test"
+    )
+
+    assert message.is_callable()
+    now = datetime.datetime(2020, 5, 10, 0, 0, 0)
+    now_after_delay = datetime.datetime(2020, 5, 10, 0, 0, 40)
+    # delay_secondを増やした状態で正しくcallableの値を返すか
+    with unittest.mock.patch("datetime.datetime") as dt:
+        dt.now.return_value = now
+        message = Message(
+            "test", delay_seconds=30
+        )
+        assert not message.is_callable()
+
+        dt.now.return_value = now_after_delay
+        assert message.is_callable()
+
+

--- a/tests/sqs/test_queue.py
+++ b/tests/sqs/test_queue.py
@@ -3,7 +3,6 @@ from faws.sqs.queue import Queue, Message
 from unittest import mock
 import pytest
 
-
 def test_equal():
     now = datetime(2020, 5, 28, 0, 0, 0)
     with mock.patch("datetime.datetime") as dt:
@@ -15,22 +14,21 @@ def test_equal():
         assert queue != other
 
 
-
-def test_add_message(dt):
-    dt.return_value = datetime(2020, 5, 20, 0, 0, 0)
-    queue = Queue("test-queue")
-    message = queue.add_message("takerun")
-    assert message.message_id in queue.messages
-
 @mock.patch("datetime.datetime")
-@pytest.mark.parametrize("message_attr,message", [
-    {"message_body": "test", "message_attributes": None, "delay_seconds": 0},
-    {"message_body": "test", "message_attributes": None, "delay_seconds": 10},
-])
+@pytest.mark.parametrize("delay_seconds", [0, 10])
+def test_add_message(dt, delay_seconds):
+    now = datetime(2020, 5, 20, 0, 0, 0)
+    expected_deliverable_time = datetime(2020, 5, 20, 0, 0, 0 + delay_seconds)
+    dt.now.return_value = now
+    queue = Queue("test-queue")
+    message = queue.add_message("takerun", delay_seconds=delay_seconds)
+    assert message.message_id in queue.messages and message.message_deliverable_time == expected_deliverable_time
+
+
 def test_get_message():
     queue = Queue("test-queue")
 
-    with mock.patch("uuid.uuid4", return_value="1111"), mock.patch("datetime.datetime."):
+    with mock.patch("uuid.uuid4", return_value="1111"):
         message = queue.add_message("takerun")
 
         assert queue.get_message() == message

--- a/tests/sqs/test_queue.py
+++ b/tests/sqs/test_queue.py
@@ -26,13 +26,18 @@ def test_add_message(dt, delay_seconds):
     assert message.message_id in queue.messages and message.message_deliverable_time == expected_deliverable_time
 
 
-def test_get_message():
+@pytest.mark.parametrize(
+    "visibility_timeout,deliverable_second", [(0, 0), (None, 30), (45, 45)]
+)
+def test_get_message(visibility_timeout, deliverable_second):
     queue = Queue("test-queue")
-
-    with mock.patch("uuid.uuid4", return_value="1111"):
+    now = datetime(2020, 5, 1, 0, 0, 0)
+    with mock.patch("uuid.uuid4", return_value="1111"), mock.patch("datetime.datetime") as dt:
+        dt.now.return_value = now
         message = queue.add_message("takerun")
 
-        assert queue.get_message() == message
+        assert queue.get_message(visibility_timeout) == message \
+            and message.message_deliverable_time == datetime(2020, 5, 1, 0, 0, deliverable_second)
 
 
 def test_get_message_exist_uncallable_message():

--- a/tests/sqs/test_queue.py
+++ b/tests/sqs/test_queue.py
@@ -23,7 +23,10 @@ def test_add_message(dt, delay_seconds):
     dt.now.return_value = now
     queue = Queue("test-queue")
     message = queue.add_message("takerun", delay_seconds=delay_seconds)
-    assert message.message_id in queue.messages and message.message_deliverable_time == expected_deliverable_time
+    assert (
+        message.message_id in queue.messages
+        and message.message_deliverable_time == expected_deliverable_time
+    )
 
 
 @pytest.mark.parametrize(
@@ -32,12 +35,17 @@ def test_add_message(dt, delay_seconds):
 def test_get_message(visibility_timeout, deliverable_second):
     queue = Queue("test-queue")
     now = datetime(2020, 5, 1, 0, 0, 0)
-    with mock.patch("uuid.uuid4", return_value="1111"), mock.patch("datetime.datetime") as dt:
+    with mock.patch("uuid.uuid4", return_value="1111"), mock.patch(
+        "datetime.datetime"
+    ) as dt:
         dt.now.return_value = now
         message = queue.add_message("takerun")
 
-        assert queue.get_message(visibility_timeout) == message \
-            and message.message_deliverable_time == datetime(2020, 5, 1, 0, 0, deliverable_second)
+        assert queue.get_message(
+            visibility_timeout
+        ) == message and message.message_deliverable_time == datetime(
+            2020, 5, 1, 0, 0, deliverable_second
+        )
 
 
 def test_get_message_exist_uncallable_message():

--- a/tests/sqs/test_queue.py
+++ b/tests/sqs/test_queue.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from faws.sqs.queue import Queue, Message
 from unittest import mock
+import pytest
 
 
 def test_equal():
@@ -14,26 +15,22 @@ def test_equal():
         assert queue != other
 
 
-def test_add_message():
+
+def test_add_message(dt):
+    dt.return_value = datetime(2020, 5, 20, 0, 0, 0)
     queue = Queue("test-queue")
     message = queue.add_message("takerun")
     assert message.message_id in queue.messages
 
-
-def test_message_set_delay():
-    message = Message(
-        message_body="hoge",
-        message_inserted_at=datetime(2020, 5, 28, 0, 0, 0),
-        delay_seconds=10,
-    )
-
-    assert message.message_deliverable_time == datetime(2020, 5, 28, 0, 0, 10)
-
-
+@mock.patch("datetime.datetime")
+@pytest.mark.parametrize("message_attr,message", [
+    {"message_body": "test", "message_attributes": None, "delay_seconds": 0},
+    {"message_body": "test", "message_attributes": None, "delay_seconds": 10},
+])
 def test_get_message():
     queue = Queue("test-queue")
 
-    with mock.patch("uuid.uuid4", return_value="1111"):
+    with mock.patch("uuid.uuid4", return_value="1111"), mock.patch("datetime.datetime."):
         message = queue.add_message("takerun")
 
         assert queue.get_message() == message

--- a/tests/sqs/test_queue.py
+++ b/tests/sqs/test_queue.py
@@ -3,6 +3,7 @@ from faws.sqs.queue import Queue, Message
 from unittest import mock
 import pytest
 
+
 def test_equal():
     now = datetime(2020, 5, 28, 0, 0, 0)
     with mock.patch("datetime.datetime") as dt:

--- a/tests/sqs/test_server.py
+++ b/tests/sqs/test_server.py
@@ -45,10 +45,10 @@ def receive_message(client, queue_url, message_attribute_names=None):
     data = f"Action=ReceiveMessage&QueueUrl={queue_url}"
     if message_attribute_names is None:
         return client.post("/", data=data)
-    message_attribute_names_data = "&".join(
+    message_attribute_response_data = "&".join(
         [f"{k}={v}" for k, v in message_attribute_names.items()]
     )
-    return client.post("/", data=data + "&" + message_attribute_names_data)
+    return client.post("/", data=data + "&" + message_attribute_response_data)
 
 
 def test_parse_request_data():

--- a/tests/sqs/test_server.py
+++ b/tests/sqs/test_server.py
@@ -291,7 +291,7 @@ def test_send_set_delay_message(uuid, client):
                     "ReceiveMessageResult": {},
                     "ResponseMetadata": {
                         "RequestId": "725275ae-0b9b-4762-b238-436d7c65a1ac"
-                    }
+                    },
                 }
             }
         )
@@ -311,7 +311,7 @@ def test_send_set_delay_message(uuid, client):
                     },
                     "ResponseMetadata": {
                         "RequestId": "725275ae-0b9b-4762-b238-436d7c65a1ac"
-                    }
+                    },
                 }
             }
         )
@@ -337,7 +337,7 @@ def test_visibility_after_receiving(uuid, client):
                     "ReceiveMessageResult": {},
                     "ResponseMetadata": {
                         "RequestId": "725275ae-0b9b-4762-b238-436d7c65a1ac"
-                    }
+                    },
                 }
             }
         )
@@ -357,7 +357,7 @@ def test_visibility_after_receiving(uuid, client):
                     },
                     "ResponseMetadata": {
                         "RequestId": "725275ae-0b9b-4762-b238-436d7c65a1ac"
-                    }
+                    },
                 }
             }
         )


### PR DESCRIPTION
# 概要

- メッセージを作成/受信した際にvisibility timeoutの設定で配信遅延を行う
  - 10sしたら10s受信できない
  - defaultはqueueの設定を利用する
- この修正&今後Messageにわりとロジック持つことになりDataclassじゃなくなってきたので通常クラスに
